### PR TITLE
Add config and instructions for WebAssembly (WASI) build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 .DS_Store
 dist-newstyle/
+dist-wasm/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *~
 
 .DS_Store
+dist-newstyle/

--- a/README.md
+++ b/README.md
@@ -61,3 +61,7 @@ stack exec automerge-pandoc toAutomerge -- --from markdown MARKDOWN_STRING
 ```
 stack exec automerge-pandoc toAutomerge -- --from html HTML_STRING
 ```
+
+## Build for WebAssembly
+
+There are instructions for building the project for [WebAssembly](https://webassembly.org/) [here](https://github.com/arisgk/automerge-pandoc/blob/main/WASM_BUILD.md).

--- a/WASM_BUILD.md
+++ b/WASM_BUILD.md
@@ -1,0 +1,30 @@
+# Build Project for WebAssembly
+
+The project can be built for [WebAssembly](https://webassembly.org/) in order to be more easily consumed by browsers or a Node.js app.
+
+More specifically, it is also compiled as a [WASI](https://wasi.dev/) module so that the consuming app can leverage I/O and consume the CLI tool using standard output (stdout).
+
+## Prerequisites
+
+Install [Nix](https://nixos.org/) because it's the easiest way to use the [Haskell Wasm tools](https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta).
+
+## Build for WASM
+
+1. Launch a ready-made development environment before building using `nix shell 'gitlab:haskell-wasm/ghc-wasm-meta?host=gitlab.haskell.org#all_9_10' --extra-experimental-features nix-command --extra-experimental-features flakes`, as suggested in [ghc-wasm-meta](https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta#getting-started-as-a-nix-flake) docs. Note that we are using the GHC `9.10` flavour, not the latest one.
+2. Build for wasm using the following commmand: `wasm32-wasi-cabal build --project-file=cabal.project.wasm-wasi --builddir=dist-wasm`. This leverages the special cabal binary provided in development environment created by Nix and also uses the proper GHC version (`9.10`). It also leverages the `cabal.project.wasm-wasi` overrides that are needed for the project to be built for WebAssembly.
+3. The artifact you need is `dist-wasm/build/wasm32-wasi/ghc-9.10.1.20241209/automerge-pandoc-0.1.0.0/x/automerge-pandoc/build/automerge-pandoc/automerge-pandoc.wasm` (or similar). Copy it in the project where you want to leverage the Automerge Pandoc CLI.
+4. Exit the Nix development environment by typing `exit`.
+
+## Run using wasmtime
+
+You can confirm that the CLI is working by using the [wasmtime](https://wasmtime.dev/) runtime for WebAssembly. Install `wasmtime` following the instructions in the website and then run:
+
+```
+wasmtime automerge-pandoc.wasm fromAutomerge --to pandoc AUTOMERGE_SPANS_JSON
+```
+
+## Notes on the Overrides
+
+- The overrides in `cabal.project.wasm-wasi` are based mostly on https://github.com/haskell-wasm/pandoc/blob/wasm/cabal.project, which is a Pandoc build for wasm.
+- Pandoc was downgraded to version `3.5` because this was the version that was working with the wasm build at the time of the initial implementation.
+- [haskell-wasm](https://github.com/orgs/haskell-wasm/repositories) GitHub repositories is probably the best resource for packages that will work for WASM & WASI.

--- a/automerge-pandoc.cabal
+++ b/automerge-pandoc.cabal
@@ -56,7 +56,7 @@ executable automerge-pandoc
     , base >=4.7 && <5
     , bytestring >=0.12.1.0
     , optparse-applicative >=0.18.1.0
-    , pandoc >=3.5
+    , pandoc >=3.6.2
     , pandoc-types >=1.23.1
     , raw-strings-qq >=1.1
     , text >=2.1.1

--- a/automerge-pandoc.cabal
+++ b/automerge-pandoc.cabal
@@ -50,7 +50,7 @@ executable automerge-pandoc
       Paths_automerge_pandoc
   hs-source-dirs:
       app
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -rtsopts -with-rtsopts=-N
   build-depends:
       automerge-pandoc
     , base >=4.7 && <5
@@ -69,7 +69,7 @@ test-suite automerge-pandoc-test
       Paths_automerge_pandoc
   hs-source-dirs:
       test
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -rtsopts -with-rtsopts=-N
   build-depends:
       automerge-pandoc
     , base >=4.7 && <5

--- a/automerge-pandoc.cabal
+++ b/automerge-pandoc.cabal
@@ -38,7 +38,7 @@ library
     , base >=4.7 && <5
     , bytestring >=0.12.1.0
     , containers >=0.7
-    , pandoc >=3.6.2
+    , pandoc >=3.5
     , pandoc-types >=1.23.1
     , text >=2.1.1
   default-language: Haskell2010
@@ -56,7 +56,7 @@ executable automerge-pandoc
     , base >=4.7 && <5
     , bytestring >=0.12.1.0
     , optparse-applicative >=0.18.1.0
-    , pandoc >=3.6.2
+    , pandoc >=3.5
     , pandoc-types >=1.23.1
     , raw-strings-qq >=1.1
     , text >=2.1.1

--- a/automerge-pandoc.cabal
+++ b/automerge-pandoc.cabal
@@ -50,7 +50,7 @@ executable automerge-pandoc
       Paths_automerge_pandoc
   hs-source-dirs:
       app
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
   build-depends:
       automerge-pandoc
     , base >=4.7 && <5

--- a/cabal.project.local
+++ b/cabal.project.local
@@ -1,4 +1,8 @@
 if arch(wasm32)
+  -- Required for TemplateHaskell. When using wasm32-wasi-cabal from
+  -- ghc-wasm-meta, this is superseded by the global cabal.config.
+  shared: True
+
   package aeson
     flags: -ordered-keymap
 
@@ -11,13 +15,92 @@ if arch(wasm32)
   package pandoc
     flags: +embed_data_files
     
-  -- https://github.com/haskellari/time-compat/issues/37
-  -- Older versions of time don't build on WASM.
-  constraints: 
-    time installed
+  constraints:
+    Cabal installed,
+    Cabal-syntax installed,
+    array installed,
+    base installed,
+    binary installed,
+    bytestring installed,
+    containers installed,
+    deepseq installed,
+    directory installed,
+    exceptions installed,
+    filepath installed,
+    ghc installed,
+    ghc-bignum installed,
+    ghc-boot installed,
+    ghc-boot-th installed,
+    ghc-compact installed,
+    ghc-experimental installed,
+    ghc-heap installed,
+    ghc-internal installed,
+    ghc-platform installed,
+    ghc-prim installed,
+    ghc-toolchain installed,
+    ghci installed,
+    haskeline installed,
+    hpc installed,
+    integer-gmp installed,
+    mtl installed,
+    os-string installed,
+    parsec installed,
+    pretty installed,
+    process installed,
+    rts installed,
+    semaphore-compat installed,
+    stm installed,
+    system-cxx-std-lib installed,
+    template-haskell installed,
+    text installed,
+    time installed,
+    transformers installed,
+    unix installed,
+    xhtml installed
 
-  allow-newer: 
-    time
+  allow-newer:
+    all:Cabal,
+    all:Cabal-syntax,
+    all:array,
+    all:base,
+    all:binary,
+    all:bytestring,
+    all:containers,
+    all:deepseq,
+    all:directory,
+    all:exceptions,
+    all:filepath,
+    all:ghc,
+    all:ghc-bignum,
+    all:ghc-boot,
+    all:ghc-boot-th,
+    all:ghc-compact,
+    all:ghc-experimental,
+    all:ghc-heap,
+    all:ghc-internal,
+    all:ghc-platform,
+    all:ghc-prim,
+    all:ghc-toolchain,
+    all:ghci,
+    all:haskeline,
+    all:hpc,
+    all:integer-gmp,
+    all:mtl,
+    all:os-string,
+    all:parsec,
+    all:pretty,
+    all:process,
+    all:rts,
+    all:semaphore-compat,
+    all:stm,
+    all:system-cxx-std-lib,
+    all:template-haskell,
+    all:text,
+    all:time,
+    all:transformers,
+    all:unix,
+    all:xhtml,
+    all:zlib
 
   source-repository-package
     type: git
@@ -46,4 +129,10 @@ if arch(wasm32)
     type: git
     location: https://github.com/haskell-wasm/network
     tag: ab92e48e9fdf3abe214f85fdbe5301c1280e14e9
+
+  -- https://github.com/haskellari/splitmix/pull/73
+  source-repository-package
+    type: git
+    location: https://github.com/amesgen/splitmix
+    tag: cea9e31bdd849eb0c17611bb99e33d590e126164
   

--- a/cabal.project.local
+++ b/cabal.project.local
@@ -53,6 +53,12 @@ if arch(wasm32)
     location: https://github.com/haskell-wasm/hs-memory.git
     tag: a198a76c584dc2cfdcde6b431968de92a5fed65e
 
+  source-repository-package
+    type: git
+    location: https://github.com/haskell-wasm/xml.git
+    tag: bc793dc9bc29c92245d3482a54d326abd3ae1403
+    subdir: xml-conduit
+
   -- https://github.com/haskell/network/pull/598
   source-repository-package
     type: git

--- a/cabal.project.local
+++ b/cabal.project.local
@@ -1,21 +1,3 @@
-ignore-project: False
-extra-include-dirs: /opt/homebrew/Cellar/zlib/1.3.1/include
-extra-include-libs: /opt/homebrew/Cellar/zlib/1.3.1/lib
-
-with-compiler: /Users/aris/.ghc-wasm/wasm32-wasi-ghc/bin/wasm32-wasi-ghc
-with-hc-pkg: /Users/aris/.ghc-wasm/wasm32-wasi-ghc/bin/wasm32-wasi-ghc-pkg
-
-package *
-  hsc2hs-location: /Users/aris/.ghc-wasm/wasm32-wasi-ghc/bin/wasm32-wasi-hsc2hs
-
-program-locations
-  hsc2hs-location: /Users/aris/.ghc-wasm/wasm32-wasi-ghc/bin/wasm32-wasi-hsc2hs
-
-source-repository-package
-  type: git
-  location: https://github.com/haskell-wasm/pandoc.git
-  tag: 336228bb8d5e9bf35750cfe6b546ffb4bcd86c15
-
 if arch(wasm32)
   package aeson
     flags: -ordered-keymap

--- a/cabal.project.local
+++ b/cabal.project.local
@@ -1,0 +1,61 @@
+ignore-project: False
+extra-include-dirs: /opt/homebrew/Cellar/zlib/1.3.1/include
+extra-include-libs: /opt/homebrew/Cellar/zlib/1.3.1/lib
+
+with-compiler: /Users/aris/.ghc-wasm/wasm32-wasi-ghc/bin/wasm32-wasi-ghc
+with-hc-pkg: /Users/aris/.ghc-wasm/wasm32-wasi-ghc/bin/wasm32-wasi-ghc-pkg
+
+package *
+  hsc2hs-location: /Users/aris/.ghc-wasm/wasm32-wasi-ghc/bin/wasm32-wasi-hsc2hs
+
+program-locations
+  hsc2hs-location: /Users/aris/.ghc-wasm/wasm32-wasi-ghc/bin/wasm32-wasi-hsc2hs
+
+source-repository-package
+  type: git
+  location: https://github.com/haskell-wasm/pandoc.git
+  tag: 336228bb8d5e9bf35750cfe6b546ffb4bcd86c15
+
+if arch(wasm32)
+  package aeson
+    flags: -ordered-keymap
+
+  package crypton
+    ghc-options: -optc-DARGON2_NO_THREADS
+
+  package digest
+    flags: -pkg-config
+
+  package pandoc
+    flags: +embed_data_files
+    
+  -- https://github.com/haskellari/time-compat/issues/37
+  -- Older versions of time don't build on WASM.
+  constraints: 
+    time installed
+
+  allow-newer: 
+    time
+
+  source-repository-package
+    type: git
+    location: https://github.com/haskell-wasm/pandoc
+    tag: 336228bb8d5e9bf35750cfe6b546ffb4bcd86c15
+
+  source-repository-package
+    type: git
+    location: https://github.com/haskell-wasm/foundation.git
+    tag: 8e6dd48527fb429c1922083a5030ef88e3d58dd3
+    subdir: basement
+
+  source-repository-package
+    type: git
+    location: https://github.com/haskell-wasm/hs-memory.git
+    tag: a198a76c584dc2cfdcde6b431968de92a5fed65e
+
+  -- https://github.com/haskell/network/pull/598
+  source-repository-package
+    type: git
+    location: https://github.com/haskell-wasm/network
+    tag: ab92e48e9fdf3abe214f85fdbe5301c1280e14e9
+  

--- a/cabal.project.wasm-wasi
+++ b/cabal.project.wasm-wasi
@@ -1,3 +1,5 @@
+packages: .
+
 if arch(wasm32)
   -- Required for TemplateHaskell. When using wasm32-wasi-cabal from
   -- ghc-wasm-meta, this is superseded by the global cabal.config.
@@ -135,4 +137,4 @@ if arch(wasm32)
     type: git
     location: https://github.com/amesgen/splitmix
     tag: cea9e31bdd849eb0c17611bb99e33d590e126164
-  
+    

--- a/package.yaml
+++ b/package.yaml
@@ -38,7 +38,7 @@ library:
     - aeson >= 2.2.3.0
     - bytestring >= 0.12.1.0
     - text >= 2.1.1
-    - pandoc >= 3.6.2
+    - pandoc >= 3.5
     - pandoc-types >= 1.23.1
     - containers >= 0.7
 
@@ -47,7 +47,6 @@ executables:
     main: Main.hs
     source-dirs: app
     ghc-options:
-      - -threaded
       - -rtsopts
       - -with-rtsopts=-N
     dependencies:
@@ -64,7 +63,6 @@ tests:
     main: Spec.hs
     source-dirs: test
     ghc-options:
-      - -threaded
       - -rtsopts
       - -with-rtsopts=-N
     dependencies:

--- a/package.yaml
+++ b/package.yaml
@@ -46,9 +46,6 @@ executables:
   automerge-pandoc:
     main: Main.hs
     source-dirs: app
-    ghc-options:
-      - -rtsopts
-      - -with-rtsopts=-N
     dependencies:
       - automerge-pandoc
       - bytestring >= 0.12.1.0


### PR DESCRIPTION
This PR adds the required configuration and instructions to build the CLI for [WebAssembly](https://webassembly.org/), as a [WASI](https://wasi.dev/) module that can be consumed via standard output (`stdout`).

**Note** Pandoc was downgraded to version `3.5` to support this.