### PR TITLE
Add lists and block hierarchy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ CLI tool that converts [Automerge rich text](https://automerge.org/docs/under-th
 
 ## A Note on Maturity
 
-Not all Automerge rich text features are supported yet and most probably some corner cases are not handled properly yet. The emphasis was on first covering heading and paragraph blocks and bold and italics marks. Incrementally, this repo will be extended to cover the [Automerge Rich Text schema](https://automerge.org/docs/under-the-hood/rich_text_schema/) and then to reach feature parity with some important rich text representations such as Markdown.
+Not all Automerge rich text features are supported yet and most probably some corner cases are not handled properly yet. Specifically, blockquotes and images are not implemented yet. Same with the code block language attribute. The emphasis was on first covering heading and paragraph blocks and bold and italics marks. Incrementally, this repo will be extended to cover the [Automerge Rich Text schema](https://automerge.org/docs/under-the-hood/rich_text_schema/) and then to reach feature parity with some important rich text representations such as Markdown.
 
 ## How it Works
 

--- a/automerge-pandoc.cabal
+++ b/automerge-pandoc.cabal
@@ -38,6 +38,7 @@ library
     , base >=4.7 && <5
     , bytestring >=0.12.1.0
     , containers >=0.7
+    , mtl >=2.3.1
     , pandoc >=3.5
     , pandoc-types >=1.23.1
     , text >=2.1.1

--- a/package.yaml
+++ b/package.yaml
@@ -41,6 +41,7 @@ library:
     - pandoc >= 3.5
     - pandoc-types >= 1.23.1
     - containers >= 0.7
+    - mtl >= 2.3.1
   other-modules:
     - Utils.JSON
     - Utils.Sequence

--- a/src/Automerge.hs
+++ b/src/Automerge.hs
@@ -145,14 +145,14 @@ parseAutomergeSpans :: BL.ByteString -> Either String [AutomergeSpan]
 parseAutomergeSpans = eitherDecode
 
 instance ToJSON AutomergeSpan where
-  toJSON (BlockSpan blockMarker _) = case blockMarker of
+  toJSON (BlockSpan blockMarker parents) = case blockMarker of
     ParagraphMarker ->
       object
         [ "type" .= T.pack "block",
           "value"
             .= object
               [ "isEmbed" .= Bool False,
-                "parents" .= ([] :: [T.Text]),
+                "parents" .= parents,
                 "type" .= T.pack "paragraph",
                 "attrs" .= (KM.empty :: KM.KeyMap T.Text)
               ]
@@ -163,7 +163,7 @@ instance ToJSON AutomergeSpan where
           "value"
             .= object
               [ "isEmbed" .= Bool False,
-                "parents" .= ([] :: [T.Text]),
+                "parents" .= parents,
                 "type" .= T.pack "heading",
                 "attrs" .= object ["level" .= level]
               ]
@@ -174,7 +174,7 @@ instance ToJSON AutomergeSpan where
           "value"
             .= object
               [ "isEmbed" .= Bool False,
-                "parents" .= ([] :: [T.Text]),
+                "parents" .= parents,
                 "type" .= T.pack "code-block",
                 "attrs" .= (KM.empty :: KM.KeyMap T.Text)
               ]
@@ -196,7 +196,7 @@ instance ToJSON AutomergeSpan where
           "value"
             .= object
               [ "isEmbed" .= Bool True,
-                "parents" .= ([] :: [T.Text]),
+                "parents" .= parents,
                 "type" .= T.pack "ordered-list-item",
                 "attrs" .= (KM.empty :: KM.KeyMap T.Text)
               ]
@@ -207,7 +207,7 @@ instance ToJSON AutomergeSpan where
           "value"
             .= object
               [ "isEmbed" .= Bool False,
-                "parents" .= ([] :: [T.Text]),
+                "parents" .= parents,
                 "type" .= T.pack "unordered-list-item",
                 "attrs" .= (KM.empty :: KM.KeyMap T.Text)
               ]
@@ -218,7 +218,7 @@ instance ToJSON AutomergeSpan where
           "value"
             .= object
               [ "isEmbed" .= Bool False,
-                "parents" .= ([] :: [T.Text]),
+                "parents" .= parents,
                 "type" .= T.pack "image",
                 "attrs" .= (KM.empty :: KM.KeyMap T.Text)
               ]

--- a/src/Automerge.hs
+++ b/src/Automerge.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module Automerge (parseAutomergeSpans, Span (..), BlockMarker (..), Heading (..), HeadingLevel (..), BlockSpan (..), TextSpan (..), Mark (..), Link (..), toJSONText, takeUntilBlockSpan, isTopLevelBlock, isParent, isSiblingListItem) where
+module Automerge (parseAutomergeSpans, Span (..), BlockMarker (..), Heading (..), HeadingLevel (..), BlockSpan (..), BlockType (..), TextSpan (..), Mark (..), Link (..), toJSONText, takeUntilBlockSpan, isTopLevelBlock, isParent, isSiblingListItem) where
 
 import Data.Aeson (FromJSON (parseJSON), Object, ToJSON (toJSON), Value (Bool, String), eitherDecode, encode, object, withObject, withScientific, withText, (.!=), (.:), (.:?), (.=))
 import qualified Data.Aeson.Key as K

--- a/src/Automerge.hs
+++ b/src/Automerge.hs
@@ -249,8 +249,9 @@ takeUntilBlockSpan (x : xs) = case x of
 isTopLevelBlock :: BlockSpan -> Bool
 isTopLevelBlock (AutomergeBlock _ parents) = null parents
 
-isParent :: BlockSpan -> BlockSpan -> Bool
-isParent (AutomergeBlock _ parents) (AutomergeBlock _ candidateParents) = isProperPrefix parents candidateParents
+isParent :: Maybe BlockSpan -> BlockSpan -> Bool
+isParent (Just (AutomergeBlock _ parents)) (AutomergeBlock _ candidateParents) = isProperPrefix parents candidateParents
+isParent Nothing blockSpan = isTopLevelBlock blockSpan
 
 isSiblingListItem :: BlockSpan -> BlockSpan -> Bool
 isSiblingListItem (AutomergeBlock UnorderedListItemMarker parents) (AutomergeBlock UnorderedListItemMarker candidateParents) = parents == candidateParents

--- a/src/PandocReader.hs
+++ b/src/PandocReader.hs
@@ -99,7 +99,7 @@ treeToPandocBlocks :: Tree DocNode -> Either PandocError Blocks
 treeToPandocBlocks tree = sequenceA (foldTree treeNodeToPandocBlock tree) >>= getBlockSeq
 
 getBlockSeq :: [BlockOrInlines] -> Either PandocError Blocks
-getBlockSeq = undefined
+getBlockSeq = fmap fromList . traverse assertBlock
 
 data BlockOrInlines = BlockElement Block | InlineElement Inlines
 

--- a/src/PandocReader.hs
+++ b/src/PandocReader.hs
@@ -21,7 +21,9 @@ buildDocNode (currentSpan, remainingSpans) = case currentSpan of
   (TextSpan textSpan) -> (InlineNode $ convertTextSpan textSpan, [])
 
 getChildSeeds :: BlockSpan -> [AutomergeSpan] -> [(AutomergeSpan, [AutomergeSpan])]
-getChildSeeds blockSpan = (map (\x -> (x, [])) . takeUntilBlockSpan) <> (findChildBlocksWithRemainder blockSpan)
+getChildSeeds blockSpan = (addSeedWithNoChildren . takeUntilBlockSpan) <> (findChildBlocksWithRemainder blockSpan)
+  where
+    addSeedWithNoChildren = map (\x -> (x, []))
 
 findChildBlocksWithRemainder :: BlockSpan -> [AutomergeSpan] -> [(AutomergeSpan, [AutomergeSpan])]
 findChildBlocksWithRemainder blockSpan spans = addChildBlocks spans

--- a/src/PandocReader.hs
+++ b/src/PandocReader.hs
@@ -157,11 +157,11 @@ treeNodeToPandocBlock node childrenNodes = case node of
   -- TODO: Remove when all block types are handled
   _ -> undefined
   where
-    concatInlines :: [Either PandocError Pandoc.Inlines] -> Either PandocError Pandoc.Inlines
-    concatInlines eitherInlines = fmap mconcat $ sequenceA eitherInlines
-
     concatChildrenInlines :: [[Either PandocError BlockOrInlines]] -> Either PandocError Pandoc.Inlines
     concatChildrenInlines children = concatInlines $ map (>>= assertInlines) $ concat children
+      where
+        concatInlines :: [Either PandocError Pandoc.Inlines] -> Either PandocError Pandoc.Inlines
+        concatInlines eitherInlines = fmap mconcat $ sequenceA eitherInlines
 
     concatAdjacentInlines :: [Either PandocError BlockOrInlines] -> [Either PandocError BlockOrInlines]
     concatAdjacentInlines = foldr mergeOrAppendAdjacent []

--- a/src/PandocReader.hs
+++ b/src/PandocReader.hs
@@ -15,7 +15,7 @@ convertAutomergeSpans :: [AutomergeSpan] -> Blocks
 convertAutomergeSpans = foldl' convertAutomergeSpan (Many Seq.Empty)
 
 convertAutomergeSpan :: Blocks -> AutomergeSpan -> Blocks
-convertAutomergeSpan acc (BlockSpan blockSpan) = acc <> convertBlockSpan blockSpan
+convertAutomergeSpan acc (BlockSpan blockSpan _) = acc <> convertBlockSpan blockSpan
 convertAutomergeSpan acc (TextSpan textSpan) = case lastValue acc of
   Nothing -> acc <> convertAndWrapToParagraph textSpan
   Just block -> withoutLast acc <> convertAndAddTo block textSpan

--- a/src/PandocReader.hs
+++ b/src/PandocReader.hs
@@ -4,15 +4,14 @@ import Automerge (AutomergeSpan (..), BlockMarker (..), BlockSpan (..), Heading 
 import Control.Monad.Except (throwError)
 import Data.List (find, groupBy)
 import Data.Maybe (fromMaybe)
-import Data.Sequence as Seq (Seq (Empty))
 import qualified Data.Text as T
 import Data.Tree (Tree (Node), drawTree, foldTree, unfoldForest)
 import Debug.Trace
 import Text.Pandoc (PandocError (PandocSyntaxMapError))
-import Text.Pandoc.Builder (Blocks, Inlines, Many (..), blockQuote, codeBlockWith, doc, emph, fromList, headerWith, link, para, str, strong, toList)
+import Text.Pandoc.Builder (Blocks, Inlines, doc, emph, fromList, link, str, strong, toList)
 import Text.Pandoc.Class
 import Text.Pandoc.Definition
-import Utils.Sequence (firstValue, lastValue, withoutLast)
+import Utils.Sequence (firstValue)
 
 data BlockNode = PandocBlock Block | BulletListItem | OrderedListItem deriving (Show)
 
@@ -155,39 +154,6 @@ treeNodeToPandocBlock node childrenNodes = case node of
 
     firstInline :: Inlines -> Maybe Inline
     firstInline = firstValue
-
-toPandoc'' :: (PandocMonad m) => [AutomergeSpan] -> m Pandoc
-toPandoc'' spans = pure . doc $ convertAutomergeSpans spans
-
-convertAutomergeSpans :: [AutomergeSpan] -> Blocks
-convertAutomergeSpans = foldl' convertAutomergeSpan (Many Seq.Empty)
-
-convertAutomergeSpan :: Blocks -> AutomergeSpan -> Blocks
-convertAutomergeSpan acc (BlockSpan (AutomergeBlock blockMarker _)) = acc <> (fromList [convertBlockMarker blockMarker])
-convertAutomergeSpan acc (TextSpan textSpan) = case lastValue acc of
-  Nothing -> acc <> convertAndWrapToParagraph textSpan
-  Just block -> withoutLast acc <> convertAndAddTo block textSpan
-
-convertBlockMarker :: BlockMarker -> Block
-convertBlockMarker blockSpan = case blockSpan of
-  ParagraphMarker -> Para []
-  HeadingMarker (Heading (HeadingLevel level)) -> Header level nullAttr []
-  CodeBlockMarker -> CodeBlock nullAttr T.empty
-  _ -> undefined -- more blocks to be implemented
-
-convertAndWrapToParagraph :: TextSpan -> Blocks
-convertAndWrapToParagraph = para . convertTextSpan
-
-convertAndAddTo :: Block -> TextSpan -> Blocks
-convertAndAddTo block textSpan = case block of
-  Para inlines -> para $ addTextSpanToInlines (fromList inlines) textSpan
-  Header level attr inlines -> headerWith attr level $ addTextSpanToInlines (fromList inlines) textSpan
-  CodeBlock attr _ -> codeBlockWith attr $ value textSpan
-  BlockQuote _ -> blockQuote $ convertAndWrapToParagraph textSpan
-  _ -> undefined
-
-addTextSpanToInlines :: Inlines -> TextSpan -> Inlines
-addTextSpanToInlines inlines textSpan = inlines <> convertTextSpan textSpan
 
 convertTextSpan :: TextSpan -> Inlines
 convertTextSpan = convertMarksToInlines <*> convertTextToInlines

--- a/src/PandocReader.hs
+++ b/src/PandocReader.hs
@@ -104,9 +104,7 @@ buildBlockNode blockMarker = case blockMarker of
   _ -> undefined -- more blocks to be implemented
 
 toPandoc :: (PandocMonad m) => [Automerge.Span] -> m Pandoc.Pandoc
-toPandoc spans = case convertSpansToBlocks spans of
-  Left err -> throwError err
-  Right blocks -> pure $ Pandoc.doc blocks
+toPandoc = (either throwError (pure . Pandoc.doc)) . convertSpansToBlocks
   where
     convertSpansToBlocks :: [Automerge.Span] -> Either PandocError Pandoc.Blocks
     convertSpansToBlocks = fromMaybe (Right $ Pandoc.fromList []) . fmap treeToPandocBlocks . buildTree

--- a/src/PandocReader.hs
+++ b/src/PandocReader.hs
@@ -18,14 +18,12 @@ data BlockNode = PandocBlock Block | BulletListItem | OrderedListItem deriving (
 
 data DocNode = Root | BlockNode BlockNode | InlineNode Inlines deriving (Show)
 
-traceTree :: Maybe (Tree DocNode) -> Maybe (Tree DocNode)
-traceTree maybeTree = case maybeTree of
-  Nothing -> Nothing
-  Just tree -> Debug.Trace.trace (drawTree $ fmap show tree) Just tree
+traceTree :: Tree DocNode -> Tree DocNode
+traceTree tree = Debug.Trace.trace (drawTree $ fmap show tree) tree
 
 buildTree :: [AutomergeSpan] -> Maybe (Tree DocNode)
 buildTree [] = Nothing
-buildTree spans = traceTree $ Just (groupListItems (buildRawTree spans))
+buildTree spans = fmap traceTree $ Just (groupListItems (buildRawTree spans))
 
 groupListItems :: Tree DocNode -> Tree DocNode
 groupListItems = foldTree addListNodes

--- a/src/PandocReader.hs
+++ b/src/PandocReader.hs
@@ -1,12 +1,37 @@
 module PandocReader (toPandoc) where
 
-import Automerge (AutomergeSpan (..), BlockMarker (..), Heading (..), HeadingLevel (..), Link (..), Mark (..), TextSpan (..))
+import Automerge (AutomergeSpan (..), BlockMarker (..), BlockSpan (..), Heading (..), HeadingLevel (..), Link (..), Mark (..), TextSpan (..), isParent, takeUntilBlockSpan)
 import Data.Sequence as Seq (Seq (Empty))
 import qualified Data.Text as T
-import Text.Pandoc.Builder (Blocks, Inlines, Many (..), blockQuote, codeBlock, codeBlockWith, doc, emph, fromList, header, headerWith, link, para, str, strong)
+import Data.Tree (Tree, unfoldTree)
+import Text.Pandoc.Builder (Blocks, Inlines, Many (..), blockQuote, codeBlockWith, doc, emph, fromList, headerWith, link, para, str, strong)
 import Text.Pandoc.Class
 import Text.Pandoc.Definition
 import Utils.Sequence (lastValue, withoutLast)
+
+data DocNode = BlockNode Block | InlineNode Inlines
+
+buildTree :: [AutomergeSpan] -> Maybe (Tree DocNode)
+buildTree [] = Nothing
+buildTree (currentSpan : restSpans) = Just $ unfoldTree buildDocNode (currentSpan, restSpans)
+
+buildDocNode :: (AutomergeSpan, [AutomergeSpan]) -> (DocNode, [(AutomergeSpan, [AutomergeSpan])])
+buildDocNode (currentSpan, remainingSpans) = case currentSpan of
+  (BlockSpan blockSpan@(AutomergeBlock blockMarker _)) -> (BlockNode $ convertBlockMarker blockMarker, getChildSeeds blockSpan remainingSpans)
+  (TextSpan textSpan) -> (InlineNode $ convertTextSpan textSpan, [])
+
+getChildSeeds :: BlockSpan -> [AutomergeSpan] -> [(AutomergeSpan, [AutomergeSpan])]
+getChildSeeds blockSpan = (map (\x -> (x, [])) . takeUntilBlockSpan) <> (findChildBlocksWithRemainder blockSpan)
+
+findChildBlocksWithRemainder :: BlockSpan -> [AutomergeSpan] -> [(AutomergeSpan, [AutomergeSpan])]
+findChildBlocksWithRemainder blockSpan spans = addChildBlocks spans
+  where
+    addChildBlocks [] = []
+    addChildBlocks (x : xs) = case x of
+      -- If a child span is encountered, add it to the list (along with the remainder)
+      -- using the cons operator and continue with the recursion
+      BlockSpan b | isParent blockSpan b -> (BlockSpan b, xs) : addChildBlocks xs
+      _ -> addChildBlocks xs
 
 toPandoc :: (PandocMonad m) => [AutomergeSpan] -> m Pandoc
 toPandoc spans = pure . doc $ convertAutomergeSpans spans
@@ -15,17 +40,16 @@ convertAutomergeSpans :: [AutomergeSpan] -> Blocks
 convertAutomergeSpans = foldl' convertAutomergeSpan (Many Seq.Empty)
 
 convertAutomergeSpan :: Blocks -> AutomergeSpan -> Blocks
-convertAutomergeSpan acc (BlockSpan blockSpan _) = acc <> convertBlockSpan blockSpan
+convertAutomergeSpan acc (BlockSpan (AutomergeBlock blockMarker _)) = acc <> (fromList [convertBlockMarker blockMarker])
 convertAutomergeSpan acc (TextSpan textSpan) = case lastValue acc of
   Nothing -> acc <> convertAndWrapToParagraph textSpan
   Just block -> withoutLast acc <> convertAndAddTo block textSpan
 
-convertBlockSpan :: BlockMarker -> Blocks
-convertBlockSpan blockSpan = case blockSpan of
-  ParagraphMarker -> para (Many Seq.Empty)
-  HeadingMarker (Heading (HeadingLevel level)) -> header level $ Many Seq.Empty
-  CodeBlockMarker -> codeBlock T.empty
-  BlockQuoteMarker -> blockQuote $ Many Seq.Empty
+convertBlockMarker :: BlockMarker -> Block
+convertBlockMarker blockSpan = case blockSpan of
+  ParagraphMarker -> Para []
+  HeadingMarker (Heading (HeadingLevel level)) -> Header level nullAttr []
+  CodeBlockMarker -> CodeBlock nullAttr T.empty
   _ -> undefined -- more blocks to be implemented
 
 convertAndWrapToParagraph :: TextSpan -> Blocks

--- a/src/PandocReader.hs
+++ b/src/PandocReader.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module PandocReader (toPandoc) where
 
 import Automerge (BlockMarker (..), BlockSpan (..), Heading (..), HeadingLevel (..), Link (..), Mark (..), Span (..), TextSpan (..), isParent, takeUntilBlockSpan)
@@ -119,10 +121,10 @@ data BlockOrInlines = BlockElement Pandoc.Block | InlineElement Pandoc.Inlines
 
 assertBlock :: BlockOrInlines -> Either PandocError Pandoc.Block
 assertBlock (BlockElement block) = Right block
-assertBlock (InlineElement _) = Left $ PandocSyntaxMapError $ T.pack "Error in mapping: found orphan inline node"
+assertBlock (InlineElement _) = Left $ PandocSyntaxMapError "Error in mapping: found orphan inline node"
 
 assertInlines :: BlockOrInlines -> Either PandocError Pandoc.Inlines
-assertInlines (BlockElement _) = Left $ PandocSyntaxMapError $ T.pack "Error in mapping: found block node in inline node slot"
+assertInlines (BlockElement _) = Left $ PandocSyntaxMapError "Error in mapping: found block node in inline node slot"
 assertInlines (InlineElement inlines) = Right $ inlines
 
 treeNodeToPandocBlock :: DocNode -> [[Either PandocError BlockOrInlines]] -> [Either PandocError BlockOrInlines]
@@ -138,7 +140,7 @@ treeNodeToPandocBlock node childrenNodes = case node of
     Left err -> [Left err]
     Right inlines -> case firstInline inlines of
       Just (Str text) -> [Right $ BlockElement $ Pandoc.CodeBlock attr text]
-      _ -> [Left $ PandocSyntaxMapError $ T.pack "Error in mapping: Could not extract code block text"]
+      _ -> [Left $ PandocSyntaxMapError "Error in mapping: Could not extract code block text"]
   (BlockNode (BulletListItem)) -> wrapInlinesToPlain $ concat childrenNodes
   (BlockNode (OrderedListItem)) -> wrapInlinesToPlain $ concat childrenNodes
   (BlockNode (PandocBlock (Pandoc.BulletList _))) -> case mapToChildBlocks childrenNodes of

--- a/src/PandocReader.hs
+++ b/src/PandocReader.hs
@@ -45,33 +45,32 @@ groupListItems :: Tree DocNode -> Tree DocNode
 groupListItems = foldTree addListNodes
   where
     addListNodes :: DocNode -> [Tree DocNode] -> Tree DocNode
-    addListNodes node subtrees = case node of
-      Root -> Node Root $ groupAdjacentListItems subtrees
-      BlockNode _ -> Node node $ groupAdjacentListItems subtrees
-      InlineNode _ -> Node node subtrees
+    addListNodes node subtrees = Node node $ case node of
+      Root -> groupAdjacentListItems subtrees
+      BlockNode _ -> groupAdjacentListItems subtrees
+      InlineNode _ -> subtrees
       where
-        groupAdjacentListItems :: [Tree DocNode] -> [Tree DocNode]
-        groupAdjacentListItems = concat . map nestListItemGroupsUnderList . groupBy isAdjacentListItemNode
-          where
-            isAdjacentListItemNode :: Tree DocNode -> Tree DocNode -> Bool
-            isAdjacentListItemNode (Node (BlockNode (BulletListItem)) _) (Node (BlockNode (BulletListItem)) _) = True
-            isAdjacentListItemNode (Node (BlockNode (OrderedListItem)) _) (Node (BlockNode (OrderedListItem)) _) = True
-            isAdjacentListItemNode _ _ = False
 
-            nestListItemGroupsUnderList :: [Tree DocNode] -> [Tree DocNode]
-            nestListItemGroupsUnderList group = case (find listItemInGroup group) of
-              Nothing -> group
-              Just item -> case item of
-                -- add bullet list node
-                (Node (BlockNode (BulletListItem)) _) -> [Node (BlockNode $ PandocBlock $ Pandoc.BulletList []) group]
-                -- add ordered list node
-                (Node (BlockNode (OrderedListItem)) _) -> [Node (BlockNode $ PandocBlock $ Pandoc.OrderedList (1, DefaultStyle, DefaultDelim) []) group]
-                _ -> group
-              where
-                listItemInGroup :: Tree DocNode -> Bool
-                listItemInGroup (Node (BlockNode (BulletListItem)) _) = True
-                listItemInGroup (Node (BlockNode (OrderedListItem)) _) = True
-                listItemInGroup _ = False
+groupAdjacentListItems :: [Tree DocNode] -> [Tree DocNode]
+groupAdjacentListItems = concatMap nestListItemGroupsUnderList . groupBy isAdjacentListItemNode
+  where
+    isAdjacentListItemNode :: Tree DocNode -> Tree DocNode -> Bool
+    isAdjacentListItemNode (Node (BlockNode (BulletListItem)) _) (Node (BlockNode (BulletListItem)) _) = True
+    isAdjacentListItemNode (Node (BlockNode (OrderedListItem)) _) (Node (BlockNode (OrderedListItem)) _) = True
+    isAdjacentListItemNode _ _ = False
+
+    nestListItemGroupsUnderList :: [Tree DocNode] -> [Tree DocNode]
+    nestListItemGroupsUnderList group = case (find listItemInGroup group) of
+      -- add bullet list node
+      Just (Node (BlockNode (BulletListItem)) _) -> [Node (BlockNode $ PandocBlock $ Pandoc.BulletList []) group]
+      -- add ordered list node
+      Just (Node (BlockNode (OrderedListItem)) _) -> [Node (BlockNode $ PandocBlock $ Pandoc.OrderedList (1, DefaultStyle, DefaultDelim) []) group]
+      _ -> group
+
+listItemInGroup :: Tree DocNode -> Bool
+listItemInGroup (Node (BlockNode (BulletListItem)) _) = True
+listItemInGroup (Node (BlockNode (OrderedListItem)) _) = True
+listItemInGroup _ = False
 
 buildRawTree :: NonEmpty Automerge.Span -> Tree DocNode
 buildRawTree spans = Node Root $ unfoldForest buildDocNode $ getChildBlockSeeds Nothing $ Data.List.NonEmpty.toList spans

--- a/src/PandocReader.hs
+++ b/src/PandocReader.hs
@@ -37,7 +37,7 @@ traceTree :: Tree DocNode -> Tree DocNode
 traceTree tree = Debug.Trace.trace (drawTree $ fmap show tree) tree
 
 buildTree :: [Automerge.Span] -> Maybe (Tree DocNode)
-buildTree = fmap (traceTree . groupListItems . buildRawTree) . nonEmpty
+buildTree = (fmap (traceTree . groupListItems . buildRawTree)) . nonEmpty
 
 groupListItems :: Tree DocNode -> Tree DocNode
 groupListItems = foldTree addListNodes

--- a/src/PandocReader.hs
+++ b/src/PandocReader.hs
@@ -6,20 +6,26 @@ import Data.List (find, groupBy)
 import Data.Maybe (fromMaybe)
 import Data.Sequence as Seq (Seq (Empty))
 import qualified Data.Text as T
-import Data.Tree (Tree (Node), foldTree, unfoldForest)
+import Data.Tree (Tree (Node), drawTree, foldTree, unfoldForest)
+import Debug.Trace
 import Text.Pandoc (PandocError (PandocSyntaxMapError))
 import Text.Pandoc.Builder (Blocks, Inlines, Many (..), blockQuote, codeBlockWith, doc, emph, fromList, headerWith, link, para, str, strong, toList)
 import Text.Pandoc.Class
 import Text.Pandoc.Definition
 import Utils.Sequence (firstValue, lastValue, withoutLast)
 
-data BlockNode = PandocBlock Block | BulletListItem | OrderedListItem
+data BlockNode = PandocBlock Block | BulletListItem | OrderedListItem deriving (Show)
 
-data DocNode = Root | BlockNode BlockNode | InlineNode Inlines
+data DocNode = Root | BlockNode BlockNode | InlineNode Inlines deriving (Show)
+
+traceTree :: Maybe (Tree DocNode) -> Maybe (Tree DocNode)
+traceTree maybeTree = case maybeTree of
+  Nothing -> Nothing
+  Just tree -> Debug.Trace.trace (drawTree $ fmap show tree) Just tree
 
 buildTree :: [AutomergeSpan] -> Maybe (Tree DocNode)
 buildTree [] = Nothing
-buildTree spans = Just $ groupListItems $ buildRawTree spans
+buildTree spans = traceTree $ Just (groupListItems (buildRawTree spans))
 
 groupListItems :: Tree DocNode -> Tree DocNode
 groupListItems = foldTree addListNodes

--- a/src/PandocReader.hs
+++ b/src/PandocReader.hs
@@ -21,9 +21,9 @@ buildDocNode (currentSpan, remainingSpans) = case currentSpan of
   (TextSpan textSpan) -> (InlineNode $ convertTextSpan textSpan, [])
 
 getChildSeeds :: BlockSpan -> [AutomergeSpan] -> [(AutomergeSpan, [AutomergeSpan])]
-getChildSeeds blockSpan = (addSeedWithNoChildren . takeUntilBlockSpan) <> (findChildBlocksWithRemainder blockSpan)
+getChildSeeds blockSpan = (addChildlessSeed . takeUntilBlockSpan) <> (findChildBlocksWithRemainder blockSpan)
   where
-    addSeedWithNoChildren = map (\x -> (x, []))
+    addChildlessSeed = map (\x -> (x, []))
 
 findChildBlocksWithRemainder :: BlockSpan -> [AutomergeSpan] -> [(AutomergeSpan, [AutomergeSpan])]
 findChildBlocksWithRemainder blockSpan spans = addChildBlocks spans

--- a/src/PandocReader.hs
+++ b/src/PandocReader.hs
@@ -49,7 +49,6 @@ groupListItems = foldTree addListNodes
       Root -> groupAdjacentListItems subtrees
       BlockNode _ -> groupAdjacentListItems subtrees
       InlineNode _ -> subtrees
-      where
 
 groupAdjacentListItems :: [Tree DocNode] -> [Tree DocNode]
 groupAdjacentListItems = concatMap nestListItemGroupsUnderList . groupBy isAdjacentListItemNode

--- a/src/PandocWriter.hs
+++ b/src/PandocWriter.hs
@@ -15,9 +15,9 @@ blocksToAutomergeSpans = concatMap blockToAutomergeSpans
 
 blockToAutomergeSpans :: Block -> [AutomergeSpan]
 blockToAutomergeSpans block = case block of
-  Para inlines -> BlockSpan ParagraphMarker : (TextSpan <$> inlinesToAutomergeTextSpans inlines)
-  Header level _ inlines -> BlockSpan (HeadingMarker $ Heading $ HeadingLevel level) : (TextSpan <$> inlinesToAutomergeTextSpans inlines)
-  CodeBlock _ text -> [BlockSpan CodeBlockMarker, TextSpan $ AutomergeText text []]
+  Para inlines -> BlockSpan ParagraphMarker [] : (TextSpan <$> inlinesToAutomergeTextSpans inlines)
+  Header level _ inlines -> BlockSpan (HeadingMarker $ Heading $ HeadingLevel level) [] : (TextSpan <$> inlinesToAutomergeTextSpans inlines)
+  CodeBlock _ text -> [BlockSpan CodeBlockMarker [], TextSpan $ AutomergeText text []]
   -- TODO: Implement blockquote, which contains a list of blocks in Pandoc
   _ -> [] -- Ignore blocks we don't recognize. TODO: Implement something more sophisticated here.
 

--- a/src/PandocWriter.hs
+++ b/src/PandocWriter.hs
@@ -1,6 +1,6 @@
 module PandocWriter (writeAutomergeSpans) where
 
-import Automerge (AutomergeSpan (..), BlockMarker (..), Heading (..), HeadingLevel (..), Link (..), Mark (..), TextSpan (..), toJSONText)
+import Automerge (AutomergeSpan (..), BlockMarker (..), BlockSpan (..), Heading (..), HeadingLevel (..), Link (..), Mark (..), TextSpan (..), toJSONText)
 import qualified Data.Text as T
 import Text.Pandoc (WriterOptions)
 import Text.Pandoc.Class (PandocMonad)
@@ -15,9 +15,9 @@ blocksToAutomergeSpans = concatMap blockToAutomergeSpans
 
 blockToAutomergeSpans :: Block -> [AutomergeSpan]
 blockToAutomergeSpans block = case block of
-  Para inlines -> BlockSpan ParagraphMarker [] : (TextSpan <$> inlinesToAutomergeTextSpans inlines)
-  Header level _ inlines -> BlockSpan (HeadingMarker $ Heading $ HeadingLevel level) [] : (TextSpan <$> inlinesToAutomergeTextSpans inlines)
-  CodeBlock _ text -> [BlockSpan CodeBlockMarker [], TextSpan $ AutomergeText text []]
+  Para inlines -> (BlockSpan $ AutomergeBlock ParagraphMarker []) : (TextSpan <$> inlinesToAutomergeTextSpans inlines)
+  Header level _ inlines -> (BlockSpan $ AutomergeBlock (HeadingMarker $ Heading $ HeadingLevel level) []) : (TextSpan <$> inlinesToAutomergeTextSpans inlines)
+  CodeBlock _ text -> [BlockSpan $ AutomergeBlock CodeBlockMarker [], TextSpan $ AutomergeText text []]
   -- TODO: Implement blockquote, which contains a list of blocks in Pandoc
   _ -> [] -- Ignore blocks we don't recognize. TODO: Implement something more sophisticated here.
 

--- a/src/PandocWriter.hs
+++ b/src/PandocWriter.hs
@@ -44,17 +44,17 @@ inlinesToAutomergeTextSpans = mergeSameMarkSpans . foldMap inlineToTextSpan
 
 mergeSameMarkSpans :: [Automerge.TextSpan] -> [Automerge.TextSpan]
 mergeSameMarkSpans = foldr mergeOrAppendAdjacent []
-
--- This is the folding function for merging the adjacent elements if their marks are the same
-mergeOrAppendAdjacent :: Automerge.TextSpan -> [Automerge.TextSpan] -> [Automerge.TextSpan]
-mergeOrAppendAdjacent x [] = [x]
--- pattern-match on: the current element (x), the one to its right (firstOfRest) and the rest of the fold
-mergeOrAppendAdjacent x (firstOfRest : rest) =
-  if marks x == marks firstOfRest
-    -- if the element's marks are the same with the one to its right, we merge them and then add them to the rest of the fold.
-    then (x <> firstOfRest) : rest
-    -- if they are not the same we end up with an extra text span in the list for the current element (we prepend it to the existing list for the fold.)
-    else x : firstOfRest : rest
+  where
+    -- This is the folding function for merging the adjacent elements if their marks are the same
+    mergeOrAppendAdjacent :: Automerge.TextSpan -> [Automerge.TextSpan] -> [Automerge.TextSpan]
+    mergeOrAppendAdjacent x [] = [x]
+    -- pattern-match on: the current element (x), the one to its right (firstOfRest) and the rest of the fold
+    mergeOrAppendAdjacent x (firstOfRest : rest) =
+      if marks x == marks firstOfRest
+        -- if the element's marks are the same with the one to its right, we merge them and then add them to the rest of the fold.
+        then (x <> firstOfRest) : rest
+        -- if they are not the same we end up with an extra text span in the list for the current element (we prepend it to the existing list for the fold.)
+        else x : firstOfRest : rest
 
 inlineToTextSpan :: Pandoc.Inline -> [Automerge.TextSpan]
 inlineToTextSpan inline = case inline of

--- a/src/PandocWriter.hs
+++ b/src/PandocWriter.hs
@@ -1,34 +1,34 @@
 module PandocWriter (writeAutomergeSpans) where
 
-import Automerge (AutomergeSpan (..), BlockMarker (..), BlockSpan (..), Heading (..), HeadingLevel (..), Link (..), Mark (..), TextSpan (..), toJSONText)
+import Automerge (BlockMarker (..), BlockSpan (..), Heading (..), HeadingLevel (..), Link (..), Mark (..), Span (..), TextSpan (..), toJSONText)
 import qualified Data.Text as T
 import Text.Pandoc (WriterOptions)
 import Text.Pandoc.Class (PandocMonad)
-import Text.Pandoc.Definition (Block (..), Inline (..), Pandoc (Pandoc))
+import Text.Pandoc.Definition as Pandoc (Block (..), Inline (..), Pandoc (Pandoc))
 
-writeAutomergeSpans :: (PandocMonad m) => WriterOptions -> Pandoc -> m T.Text
-writeAutomergeSpans _ (Pandoc _ blocks) =
+writeAutomergeSpans :: (PandocMonad m) => WriterOptions -> Pandoc.Pandoc -> m T.Text
+writeAutomergeSpans _ (Pandoc.Pandoc _ blocks) =
   pure $ toJSONText $ blocksToAutomergeSpans blocks
 
-blocksToAutomergeSpans :: [Block] -> [AutomergeSpan]
+blocksToAutomergeSpans :: [Pandoc.Block] -> [Automerge.Span]
 blocksToAutomergeSpans = concatMap blockToAutomergeSpans
 
-blockToAutomergeSpans :: Block -> [AutomergeSpan]
+blockToAutomergeSpans :: Pandoc.Block -> [Automerge.Span]
 blockToAutomergeSpans block = case block of
-  Para inlines -> (BlockSpan $ AutomergeBlock ParagraphMarker []) : (TextSpan <$> inlinesToAutomergeTextSpans inlines)
-  Header level _ inlines -> (BlockSpan $ AutomergeBlock (HeadingMarker $ Heading $ HeadingLevel level) []) : (TextSpan <$> inlinesToAutomergeTextSpans inlines)
-  CodeBlock _ text -> [BlockSpan $ AutomergeBlock CodeBlockMarker [], TextSpan $ AutomergeText text []]
+  Pandoc.Para inlines -> (Automerge.BlockSpan $ AutomergeBlock ParagraphMarker []) : (Automerge.TextSpan <$> inlinesToAutomergeTextSpans inlines)
+  Pandoc.Header level _ inlines -> (Automerge.BlockSpan $ AutomergeBlock (Automerge.HeadingMarker $ Heading $ HeadingLevel level) []) : (Automerge.TextSpan <$> inlinesToAutomergeTextSpans inlines)
+  Pandoc.CodeBlock _ text -> [Automerge.BlockSpan $ AutomergeBlock Automerge.CodeBlockMarker [], Automerge.TextSpan $ AutomergeText text []]
   -- TODO: Implement blockquote, which contains a list of blocks in Pandoc
   _ -> [] -- Ignore blocks we don't recognize. TODO: Implement something more sophisticated here.
 
-inlinesToAutomergeTextSpans :: [Inline] -> [TextSpan]
+inlinesToAutomergeTextSpans :: [Pandoc.Inline] -> [Automerge.TextSpan]
 inlinesToAutomergeTextSpans = mergeSameMarkSpans . foldMap inlineToTextSpan
 
-mergeSameMarkSpans :: [TextSpan] -> [TextSpan]
+mergeSameMarkSpans :: [Automerge.TextSpan] -> [Automerge.TextSpan]
 mergeSameMarkSpans = foldr mergeOrAppendAdjacent []
 
 -- This is the folding function for merging the adjacent elements if their marks are the same
-mergeOrAppendAdjacent :: TextSpan -> [TextSpan] -> [TextSpan]
+mergeOrAppendAdjacent :: Automerge.TextSpan -> [Automerge.TextSpan] -> [Automerge.TextSpan]
 mergeOrAppendAdjacent x [] = [x]
 -- pattern-match on: the current element (x), the one to its right (firstOfRest) and the rest of the fold
 mergeOrAppendAdjacent x (firstOfRest : rest) =
@@ -38,16 +38,16 @@ mergeOrAppendAdjacent x (firstOfRest : rest) =
     -- if they are not the same we end up with an extra text span in the list for the current element (we prepend it to the existing list for the fold.)
     else x : firstOfRest : rest
 
-inlineToTextSpan :: Inline -> [TextSpan]
+inlineToTextSpan :: Pandoc.Inline -> [Automerge.TextSpan]
 inlineToTextSpan inline = case inline of
-  Str str -> [AutomergeText str []]
-  Space -> [AutomergeText (T.pack " ") []]
-  Text.Pandoc.Definition.Strong inlines -> addMark Automerge.Strong inlines
-  Text.Pandoc.Definition.Emph inlines -> addMark Automerge.Emphasis inlines
-  Text.Pandoc.Definition.Link _ inlines (linkUrl, linkTitle) -> addMark (Automerge.LinkMark $ Automerge.Link {url = linkUrl, title = linkTitle}) inlines
+  Pandoc.Str str -> [AutomergeText str []]
+  Pandoc.Space -> [AutomergeText (T.pack " ") []]
+  Pandoc.Strong inlines -> addMark Automerge.Strong inlines
+  Pandoc.Emph inlines -> addMark Automerge.Emphasis inlines
+  Pandoc.Link _ inlines (linkUrl, linkTitle) -> addMark (Automerge.LinkMark $ Automerge.Link {url = linkUrl, title = linkTitle}) inlines
   -- TODO: Handle other inline elements
   _ -> []
 
-addMark :: Mark -> [Inline] -> [TextSpan]
+addMark :: Automerge.Mark -> [Pandoc.Inline] -> [Automerge.TextSpan]
 -- Monoidally add the mark to all text spans created for the inline elements
 addMark mark inlines = fmap (AutomergeText T.empty [mark] <>) (inlinesToAutomergeTextSpans inlines)

--- a/src/Utils/Sequence.hs
+++ b/src/Utils/Sequence.hs
@@ -1,7 +1,15 @@
-module Utils.Sequence (lastValue, withoutLast) where
+module Utils.Sequence (firstValue, lastValue, withoutLast) where
 
-import Data.Sequence as Seq (length, lookup, null, take)
+import Data.Sequence as Seq (ViewL (EmptyL, (:<)), length, lookup, null, take, viewl)
 import Text.Pandoc.Builder (Many (Many, unMany))
+
+-- Gets the first value of a sequence wrapped in Many
+firstValue :: Many a -> Maybe a
+firstValue many = case Seq.viewl xs of
+  Seq.EmptyL -> Nothing
+  x Seq.:< _ -> Just x
+  where
+    xs = unMany many
 
 -- Gets the last value of a sequence wrapped in Many
 lastValue :: Many a -> Maybe a


### PR DESCRIPTION
This PR handles mapping lists (unordered/ordered) and also adds the relevant infrastructure to properly process and transform block hierarchy when converting to/from Pandoc.