### PR TITLE
Implement inline code marks

### DIFF
--- a/src/Automerge.hs
+++ b/src/Automerge.hs
@@ -30,6 +30,7 @@ data Mark
   = Strong
   | Emphasis
   | LinkMark Link
+  | Code
   deriving (Show, Eq)
 
 newtype HeadingLevel = HeadingLevel Int deriving (Show, Eq)
@@ -153,6 +154,7 @@ parseMark (k, String txt)
 parseMark (k, Bool True) = case K.toText k of
   "strong" -> pure Strong
   "em" -> pure Emphasis
+  "__ext__code" -> pure Code
   _ -> fail $ "Unexpected mark with boolean value: " ++ T.unpack (K.toText k)
 parseMark _ = fail "Invalid format in marks"
 
@@ -252,6 +254,7 @@ instance ToJSON Span where
         Strong -> (K.fromText "strong", Bool True)
         Emphasis -> (K.fromText "em", Bool True)
         LinkMark link -> (K.fromText "link", String $ stringifyObject link)
+        Code -> (K.fromText "__ext__code", Bool True)
 
 toJSONText :: [Span] -> T.Text
 toJSONText = decodeUtf8 . BSL8.toStrict . encode

--- a/src/PandocReader.hs
+++ b/src/PandocReader.hs
@@ -20,6 +20,7 @@ import Text.Pandoc.Builder as Pandoc
     ListNumberDelim (DefaultDelim),
     ListNumberStyle (DefaultStyle),
     Pandoc,
+    code,
     doc,
     emph,
     fromList,
@@ -114,6 +115,10 @@ markToInlines mark = case mark of
   Automerge.Strong -> Pandoc.strong
   Automerge.Emphasis -> Pandoc.emph
   Automerge.LinkMark automergeLink -> Pandoc.link (url automergeLink) (title automergeLink)
+  Automerge.Code -> Pandoc.code . concatStrInlines
+    where
+      concatStrInlines :: Inlines -> T.Text
+      concatStrInlines inlines = T.concat [t | Pandoc.Str t <- Pandoc.toList inlines]
 
 groupListItems :: Tree DocNode -> Tree DocNode
 groupListItems = foldTree addListNodes

--- a/src/PandocWriter.hs
+++ b/src/PandocWriter.hs
@@ -63,6 +63,7 @@ inlineToTextSpan inline = case inline of
   Pandoc.Strong inlines -> addMark Automerge.Strong inlines
   Pandoc.Emph inlines -> addMark Automerge.Emphasis inlines
   Pandoc.Link _ inlines (linkUrl, linkTitle) -> addMark (Automerge.LinkMark $ Automerge.Link {url = linkUrl, title = linkTitle}) inlines
+  Pandoc.Code _ text -> [AutomergeText text [Automerge.Code]]
   -- TODO: Handle other inline elements
   _ -> []
 

--- a/test/AutomergeTestUtils.hs
+++ b/test/AutomergeTestUtils.hs
@@ -1,4 +1,4 @@
-module AutomergeTestUtils (paragraphSpan, heading1Span, heading2Span, heading3Span, heading4Span, heading5Span, heading6Span, textSpan, strongTextSpan, emphasisTextSpan, textSpanWithMarks, linkTextSpan, codeBlockSpan, orderedListItemSpan, unorderedListItemSpan) where
+module AutomergeTestUtils (paragraphSpan, heading1Span, heading2Span, heading3Span, heading4Span, heading5Span, heading6Span, textSpan, strongTextSpan, emphasisTextSpan, codeTextSpan, textSpanWithMarks, linkTextSpan, codeBlockSpan, orderedListItemSpan, unorderedListItemSpan) where
 
 import Automerge (BlockMarker (..), BlockSpan (..), BlockType (..), Heading (..), HeadingLevel (..), Link (..), Mark (..), Span (..), TextSpan (..))
 import qualified Data.Text as T
@@ -35,6 +35,9 @@ emphasisTextSpan str = TextSpan $ AutomergeText (T.pack str) [Emphasis]
 
 linkTextSpan :: String -> String -> String -> Span
 linkTextSpan txt linkUrl linkTitle = TextSpan $ AutomergeText (T.pack txt) [LinkMark $ Link (T.pack linkUrl) (T.pack linkTitle)]
+
+codeTextSpan :: String -> Span
+codeTextSpan str = TextSpan $ AutomergeText (T.pack str) [Code]
 
 textSpanWithMarks :: String -> [Mark] -> Span
 textSpanWithMarks str spanMarks = TextSpan $ AutomergeText (T.pack str) spanMarks

--- a/test/PandocReaderTest.hs
+++ b/test/PandocReaderTest.hs
@@ -3,12 +3,12 @@
 module PandocReaderTest (tests) where
 
 import Automerge as A (BlockType (OrderedListItemType, UnorderedListItemType), Mark (..))
-import AutomergeTestUtils as Automerge (emphasisTextSpan, heading1Span, heading4Span, linkTextSpan, orderedListItemSpan, paragraphSpan, strongTextSpan, textSpan, textSpanWithMarks, unorderedListItemSpan)
+import AutomergeTestUtils as Automerge (codeTextSpan, emphasisTextSpan, heading1Span, heading4Span, linkTextSpan, orderedListItemSpan, paragraphSpan, strongTextSpan, textSpan, textSpanWithMarks, unorderedListItemSpan)
 import PandocReader (toPandoc)
 import Test.Hspec (Spec, describe, expectationFailure, it, shouldBe)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hspec (testSpec)
-import Text.Pandoc.Builder as Pandoc (bulletList, doc, emph, fromList, header, link, orderedList, para, plain, str, strong, toList)
+import Text.Pandoc.Builder as Pandoc (bulletList, code, doc, emph, fromList, header, link, orderedList, para, plain, str, strong, toList)
 import Text.Pandoc.Class (runIO)
 
 tests :: IO TestTree
@@ -116,6 +116,23 @@ spec = do
                 -- TODO: There is no order in automerge marks but here the marks are inverted and it should be
                 -- understood and investigated why this happens.
                 [ toList $ Pandoc.para $ Pandoc.link "https://automerge.org/" "Automerge" $ Pandoc.str "Automerge"
+                ]
+
+      result <- runIO $ toPandoc input
+      case result of
+        Left err -> expectationFailure ("toPandoc failed: " <> show err)
+        Right actual -> actual `shouldBe` Pandoc.doc expected
+
+    it "handles inline code" $ do
+      let input =
+            [ Automerge.paragraphSpan [],
+              Automerge.codeTextSpan "func1"
+            ]
+
+          expected =
+            fromList $
+              concat
+                [ toList $ Pandoc.para $ Pandoc.code "func1"
                 ]
 
       result <- runIO $ toPandoc input


### PR DESCRIPTION
Adds inline code processing.

In Automerge spans, this is denoted with `__ext__code`, according to [Automerge Rich Text Schema instructions](https://automerge.org/docs/reference/under-the-hood/rich_text_schema/#marks).